### PR TITLE
fix bugs in func chr_ngram_char

### DIFF
--- a/R/ngram.R
+++ b/R/ngram.R
@@ -19,10 +19,14 @@
 chr_ngram_char <- function(x, n = 3, lower = FALSE, space = FALSE, punct = FALSE) {
   # Input validation
   stopifnot(is.character(x))
-  stopifnot(is.integer(n))
+  if (n != as.integer(n)) stop("arg 'n' must be a whole number")
+  n <- as.integer(n)
   stopifnot(is.logical(lower))
   stopifnot(is.logical(punct))
   stopifnot(is.logical(space))
+
+  # Convert any elements of x that are empty strings to NA.
+  x[x == ""] <- NA_character_
 
   # If arg "lower" is TRUE, make all chars in x lowercase.
   if (isTRUE(lower)) x <- tolower(x)


### PR DESCRIPTION
This fixes the two bugs in function `chr_ngram_char` mentioned most recently in [issue #1](https://github.com/mkearney/chr/issues/1). Going back to the examples from that issue:

Before PR:
```r
# Bug 1
chr::chr_ngram_char("cats")
#> Error: is.integer(n) is not TRUE

# Bug 2
chr::chr_ngram_char("", n = 2L)
#> Error in seq_len(length(strings) - n) : 
#>   argument must be coercible to non-negative integer
```
After PR:
```r
chr::chr_ngram_char("cats")
#> [[1]]
#> [1] "cat" "ats"

chr::chr_ngram_char("", n = 2L)
#> [[1]]
#> character(0)
```
Arg `n` can also now take any numeric input, as long as it's a whole number. Non-whole numbers will throw an error.
```r
chr::chr_ngram_char("cats", 2.5)
#> Error in chr::chr_ngram_char("cats", 2.5) : 
#>   arg 'n' must be a whole number
```