### PR TITLE
fix bugs related to valid inputs for 'x' and 'n'

### DIFF
--- a/R/ngram.R
+++ b/R/ngram.R
@@ -16,17 +16,17 @@
 #' @export
 #' @author ChrisMuir
 #' @details Thanks to ChrisMuir \(https://github.com/mkearney/chr/issues/1)
-chr_ngram_char <- function(x, n = 3, lower = FALSE, space = FALSE, punct = FALSE) {
+chr_ngram_char <- function(x, n = 3, lower = FALSE, space = FALSE, 
+                           punct = FALSE) {
   # Input validation
   stopifnot(is.character(x))
-  if (n != as.integer(n)) stop("arg 'n' must be a whole number")
+  if (n != as.integer(n) || n < 1) {
+    stop("arg 'n' must be a whole number greater than zero")
+  }
   n <- as.integer(n)
   stopifnot(is.logical(lower))
   stopifnot(is.logical(punct))
   stopifnot(is.logical(space))
-
-  # Convert any elements of x that are empty strings to NA.
-  x[x == ""] <- NA_character_
 
   # If arg "lower" is TRUE, make all chars in x lowercase.
   if (isTRUE(lower)) x <- tolower(x)
@@ -35,7 +35,7 @@ chr_ngram_char <- function(x, n = 3, lower = FALSE, space = FALSE, punct = FALSE
   if (isTRUE(punct)) x <- gsub("[[:punct:]]", "", x)
 
   # If arg "space" is TRUE, remove all white space from x.
-  if (isTRUE(space)) x <- gsub("\\s", "", x)
+  if (isTRUE(space)) x <- gsub("\\s+", "", x)
 
   # Split each element of x into individual chars.
   x <- strsplit(x, "", fixed = TRUE)
@@ -47,7 +47,9 @@ chr_ngram_char <- function(x, n = 3, lower = FALSE, space = FALSE, punct = FALSE
   # Generate ngram tokens.
   n <- n - 1
   lapply(x, function(strings) {
-    vapply(seq_len(length(strings) - n), function(char) {
+    strings_len <- length(strings) - n
+    if (is.na(strings) || strings_len < 0) return(character())
+    vapply(seq_len(strings_len), function(char) {
       paste(strings[char:(char + n)], collapse = "")
     }, character(1))
   })


### PR DESCRIPTION
For function `chr_ngram_char()`, I thought I had gotten all of the bugs in my last PR, but was wrong. Prior to this patch, all of these were throwing unintended errors or return incorrect values:
```r
chr_ngram_char(NA_character_, n = 3)
chr_ngram_char("", n = 3)
chr_ngram_char("cats", n = 6)
chr_ngram_char("cats", n = 0)
chr_ngram_char("cats", n = -1)
```
After this patch, here's the output for each:
```r
chr_ngram_char(NA_character_, n = 3)
#> [[1]]
#> character(0)

chr_ngram_char("", n = 3)
#> [[1]]
#> character(0)

chr_ngram_char("cats", n = 6)
#> [[1]]
#> character(0)

chr_ngram_char("cats", n = 0)
#> Error in chr_ngram_char("cats", n = 0) : 
#>   arg 'n' must be a whole number greater than zero

chr_ngram_char("cats", n = -1)
#> Error in chr_ngram_char("cats", n = -1) : 
#>   arg 'n' must be a whole number greater than zero
```
